### PR TITLE
fixes for time v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ __doctest = []
 
 [dependencies]
 libc = { version = "0.2.69", optional = true }
-time = { version = "0.2", optional = true }
+time = { version = "^0.2.23", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -555,7 +555,7 @@ impl NaiveTime {
         debug_assert!(frac < 1_000_000_000);
 
         let rhssecs = rhs.whole_seconds();
-        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).whole_nanoseconds();
+        let rhsfrac = rhs.subsec_nanoseconds();
         debug_assert_eq!(
             OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac as i64),
             rhs


### PR DESCRIPTION
Fixed the overflow bugs causing the test failures. Renamed `rhs` to `rem_secs` to avoid a name collision.
Also increased time version to ^0.2.23 for security reasons, as requested in https://github.com/chronotope/chrono/issues/553#issuecomment-883630753
